### PR TITLE
Disable pager issue on ironware

### DIFF
--- a/lib/ansible/plugins/terminal/ironware.py
+++ b/lib/ansible/plugins/terminal/ironware.py
@@ -46,8 +46,11 @@ class TerminalModule(TerminalBase):
         try:
             self._exec_cli_command(u'terminal length 0')
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to disable terminal pager')
-
+            try:
+                self._exec_cli_command(u'skip-page-display')
+            except AnsibleConnectionFailure:
+                raise AnsibleConnectionFailure('unable to disable terminal pager')
+                
     def on_become(self, passwd=None):
         if self._get_prompt().strip().endswith(b'#'):
             return


### PR DESCRIPTION
Disable pager command has been changed to skip-page-display on newer models. Created a nested try/except to support both the old and new models
